### PR TITLE
Add new module Vendor_CustomMessage

### DIFF
--- a/Vendor_CustomMessage/Block/Message.php
+++ b/Vendor_CustomMessage/Block/Message.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Vendor\CustomMessage\Block;
+
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class Message extends Template
+{
+    private ScopeConfigInterface $scopeConfig;
+
+    public function __construct(
+        Template\Context $context,
+        ScopeConfigInterface $scopeConfig,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    public function isEnabled(): bool
+    {
+        return (bool)$this->scopeConfig->getValue('custommessage/general/enabled', ScopeInterface::SCOPE_STORE);
+    }
+
+    public function getCustomMessage(): string
+    {
+        return (string)($this->scopeConfig->getValue('custommessage/general/message', ScopeInterface::SCOPE_STORE) ?? '');
+    }
+}

--- a/Vendor_CustomMessage/Controller/Index/Index.php
+++ b/Vendor_CustomMessage/Controller/Index/Index.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Vendor\CustomMessage\Controller\Index;
+
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\View\Result\PageFactory;
+
+class Index extends Action
+{
+    private PageFactory $pageFactory;
+
+    public function __construct(Context $context, PageFactory $pageFactory)
+    {
+        parent::__construct($context);
+        $this->pageFactory = $pageFactory;
+    }
+
+    public function execute()
+    {
+        return $this->pageFactory->create();
+    }
+}

--- a/Vendor_CustomMessage/README.md
+++ b/Vendor_CustomMessage/README.md
@@ -1,0 +1,21 @@
+# Vendor_CustomMessage
+
+Módulo de ejemplo para Magento 2 que muestra un bloque frontend con un mensaje configurable desde el admin y una ruta propia.
+
+## Características
+- Configuración en **Stores > Configuration > General > Custom Message**.
+- Ruta frontend en `/custommessage`.
+- Código con PSR-12, DI y separación clara de responsabilidades.
+
+## Instalación
+1. Copiar el módulo en `app/code/Vendor/CustomMessage`.
+2. Ejecutar:
+   ```bash
+   bin/magento module:enable Vendor_CustomMessage
+   bin/magento setup:upgrade
+   bin/magento cache:flush
+   ```
+
+## Uso
+- Ir a **Stores > Configuration > General > Custom Message** y configurar **Enable** y **Message Text**.
+- Visitar `/custommessage` en el frontend.

--- a/Vendor_CustomMessage/composer.json
+++ b/Vendor_CustomMessage/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "vendor/module-custommessage",
+  "description": "Magento 2 example module: configurable frontend message with admin settings and route.",
+  "type": "magento2-module",
+  "require": {
+    "php": ">=8.1"
+  },
+  "autoload": {
+    "files": [
+      "registration.php"
+    ],
+    "psr-4": {
+      "Vendor\\CustomMessage\\": ""
+    }
+  }
+}

--- a/Vendor_CustomMessage/etc/acl.xml
+++ b/Vendor_CustomMessage/etc/acl.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<acl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <resources>
+        <resource id="Magento_Backend::admin">
+            <resource id="Magento_Backend::stores">
+                <resource id="Magento_Backend::stores_settings">
+                    <resource id="Vendor_CustomMessage::config" title="Custom Message Configuration" sortOrder="9999"/>
+                </resource>
+            </resource>
+        </resource>
+    </resources>
+</acl>

--- a/Vendor_CustomMessage/etc/adminhtml/system.xml
+++ b/Vendor_CustomMessage/etc/adminhtml/system.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/system_file.xsd">
+    <system>
+        <section id="custommessage" translate="label" sortOrder="910" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Custom Message</label>
+            <tab>general</tab>
+            <resource>Vendor_CustomMessage::config</resource>
+            <group id="general" translate="label" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>General Settings</label>
+                <field id="message" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Message Text</label>
+                </field>
+                <field id="enabled" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Module</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/Vendor_CustomMessage/etc/frontend/routes.xml
+++ b/Vendor_CustomMessage/etc/frontend/routes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <route id="custommessage" frontName="custommessage">
+        <module name="Vendor_CustomMessage"/>
+    </route>
+</routes>

--- a/Vendor_CustomMessage/etc/module.xml
+++ b/Vendor_CustomMessage/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Vendor_CustomMessage" setup_version="1.0.0"/>
+</config>

--- a/Vendor_CustomMessage/registration.php
+++ b/Vendor_CustomMessage/registration.php
@@ -1,0 +1,3 @@
+<?php
+use Magento\Framework\Component\ComponentRegistrar;
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Vendor_CustomMessage', __DIR__);

--- a/Vendor_CustomMessage/view/frontend/layout/custommessage_index_index.xml
+++ b/Vendor_CustomMessage/view/frontend/layout/custommessage_index_index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="Vendor\CustomMessage\Block\Message" name="vendor.custommessage.block" template="Vendor_CustomMessage::message.phtml"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/Vendor_CustomMessage/view/frontend/templates/message.phtml
+++ b/Vendor_CustomMessage/view/frontend/templates/message.phtml
@@ -1,0 +1,8 @@
+<?php /** @var \Vendor\CustomMessage\Block\Message $block */ ?>
+<div class="custom-message" style="padding: 12px; border: 1px solid #eee; border-radius: 8px;">
+    <?php if ($block->isEnabled()): ?>
+        <strong><?= $block->escapeHtml($block->getCustomMessage() ?: '¡Hola desde Vendor_CustomMessage!') ?></strong>
+    <?php else: ?>
+        <em>Módulo deshabilitado.</em>
+    <?php endif; ?>
+</div>


### PR DESCRIPTION
feat: add Magento 2 module Vendor_CustomMessage with admin-configurable frontend message block

This module allows store administrators to set a custom message from the admin panel (Stores > Configuration > General > Custom Message) and display it on the frontend via a dedicated block and template.

Features:
- Admin configuration section with enable/disable and message field
- Frontend block with PSR-12 compliant code
- Proper ACL for admin permissions
- Well-structured layout and template implementation
