### PR TITLE
Add new module Vendor_DbCleanup

### DIFF
--- a/Vendor_DbCleanup/Console/Command/CleanupCommand.php
+++ b/Vendor_DbCleanup/Console/Command/CleanupCommand.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace Vendor\DbCleanup\Console\Command;
+
+use Magento\Framework\Console\Cli;
+use Magento\Framework\App\ResourceConnection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CleanupCommand extends Command
+{
+    private ResourceConnection $resource;
+
+    public function __construct(ResourceConnection $resource)
+    {
+        parent::__construct();
+        $this->resource = $resource;
+    }
+
+    protected function configure()
+    {
+        $this->setName('vendor:db:cleanup')
+            ->setDescription('Clean old logs and optionally optimize database tables')
+            ->addOption('optimize', null, InputOption::VALUE_NONE, 'Run OPTIMIZE TABLE on key log tables');
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $connection = $this->resource->getConnection();
+        $tablesToTruncate = [
+            'report_event',
+            'customer_log',
+            'report_compared_product_index',
+            'report_viewed_product_aggregated_daily',
+            'report_viewed_product_aggregated_monthly',
+            'report_viewed_product_aggregated_yearly'
+        ];
+
+        foreach ($tablesToTruncate as $table) {
+            $tableName = $this->resource->getTableName($table);
+            try {
+                $connection->truncateTable($tableName);
+                $output->writeln("<info>Truncated: {$tableName}</info>");
+            } catch (\Throwable $e) {
+                $output->writeln("<error>Failed truncating {$tableName}: {$e->getMessage()}</error>");
+            }
+        }
+
+        if ($input->getOption('optimize')) {
+            foreach ($tablesToTruncate as $table) {
+                $tableName = $this->resource->getTableName($table);
+                try {
+                    $connection->query(sprintf('OPTIMIZE TABLE `%s`', $tableName));
+                    $output->writeln("<comment>Optimized: {$tableName}</comment>");
+                } catch (\Throwable $e) {
+                    $output->writeln("<error>Failed optimizing {$tableName}: {$e->getMessage()}</error>");
+                }
+            }
+        }
+
+        $output->writeln('<info>Database cleanup complete.</info>');
+        return Cli::RETURN_SUCCESS;
+    }
+}

--- a/Vendor_DbCleanup/README.md
+++ b/Vendor_DbCleanup/README.md
@@ -1,0 +1,21 @@
+# Vendor_DbCleanup
+
+Comando CLI para limpiar tablas de logs y (opcionalmente) optimizar tablas.
+
+## Instalación
+1. Copiar en `app/code/Vendor/DbCleanup`.
+2. Ejecutar:
+   ```bash
+   bin/magento module:enable Vendor_DbCleanup
+   bin/magento setup:upgrade
+   ```
+
+## Uso
+- Limpiar logs:
+  ```bash
+  bin/magento vendor:db:cleanup
+  ```
+- Limpiar y optimizar:
+  ```bash
+  bin/magento vendor:db:cleanup --optimize
+  ```

--- a/Vendor_DbCleanup/composer.json
+++ b/Vendor_DbCleanup/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "vendor/module-dbcleanup",
+  "description": "Magento 2 CLI tool to cleanup old logs and optimize DB tables.",
+  "type": "magento2-module",
+  "require": {
+    "php": ">=8.1"
+  },
+  "autoload": {
+    "files": [
+      "registration.php"
+    ],
+    "psr-4": {
+      "Vendor\\DbCleanup\\": ""
+    }
+  }
+}

--- a/Vendor_DbCleanup/etc/di.xml
+++ b/Vendor_DbCleanup/etc/di.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="vendor_db_cleanup" xsi:type="object">Vendor\DbCleanup\Console\Command\CleanupCommand</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/Vendor_DbCleanup/etc/module.xml
+++ b/Vendor_DbCleanup/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Vendor_DbCleanup" setup_version="1.0.0"/>
+</config>

--- a/Vendor_DbCleanup/registration.php
+++ b/Vendor_DbCleanup/registration.php
@@ -1,0 +1,3 @@
+<?php
+use Magento\Framework\Component\ComponentRegistrar;
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Vendor_DbCleanup', __DIR__);


### PR DESCRIPTION
feat: add Magento 2 CLI tool Vendor_DbCleanup for database log cleanup and optimization

This module provides a custom CLI command to clean old logs and optionally optimize selected database tables, helping maintain performance in development and staging environments.

Features:
- CLI command: bin/magento vendor:db:cleanup [--optimize]
- Truncates specified log tables (e.g., report_event, customer_log)
- Optional --optimize flag to run OPTIMIZE TABLE on targeted tables
- Clean and maintainable PSR-12 compliant code
