### PR TITLE
Add new module Vendor_CountrySync

### DIFF
--- a/Vendor_CountrySync/Api/CountryServiceInterface.php
+++ b/Vendor_CountrySync/Api/CountryServiceInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Vendor\CountrySync\Api;
+
+interface CountryServiceInterface
+{
+    /**
+     * Fetch countries from REST API and persist to DB.
+     */
+    public function syncCountries(): void;
+}

--- a/Vendor_CountrySync/Console/Command/SyncCountriesCommand.php
+++ b/Vendor_CountrySync/Console/Command/SyncCountriesCommand.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Vendor\CountrySync\Console\Command;
+
+use Magento\Framework\Console\Cli;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Vendor\CountrySync\Api\CountryServiceInterface;
+
+class SyncCountriesCommand extends Command
+{
+    private CountryServiceInterface $service;
+
+    public function __construct(CountryServiceInterface $service)
+    {
+        parent::__construct();
+        $this->service = $service;
+    }
+
+    protected function configure()
+    {
+        $this->setName('vendor:countries:sync')
+            ->setDescription('Sync countries from REST API into the vendor_country table');
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->service->syncCountries();
+        $output->writeln('<info>Country sync completed.</info>');
+        return Cli::RETURN_SUCCESS;
+    }
+}

--- a/Vendor_CountrySync/Model/CountryService.php
+++ b/Vendor_CountrySync/Model/CountryService.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Vendor\CountrySync\Model;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\HTTP\Client\Curl;
+use Psr\Log\LoggerInterface;
+use Vendor\CountrySync\Api\CountryServiceInterface;
+
+class CountryService implements CountryServiceInterface
+{
+    private Curl $curl;
+    private ResourceConnection $resource;
+    private LoggerInterface $logger;
+
+    public function __construct(
+        Curl $curl,
+        ResourceConnection $resource,
+        LoggerInterface $logger
+    ) {
+        $this->curl = $curl;
+        $this->resource = $resource;
+        $this->logger = $logger;
+    }
+
+    public function syncCountries(): void
+    {
+        $endpoint = 'https://restcountries.com/v3.1/all';
+        try {
+            $this->curl->get($endpoint);
+            $status = $this->curl->getStatus();
+            if ($status !== 200) {
+                throw new \RuntimeException('REST call failed with HTTP ' . $status);
+            }
+            $data = json_decode($this->curl->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (\Throwable $e) {
+            $this->logger->error('[CountrySync] Error fetching countries: ' . $e->getMessage());
+            return;
+        }
+
+        $connection = $this->resource->getConnection();
+        $tableName = $this->resource->getTableName('vendor_country');
+
+        foreach ($data as $country) {
+            $name = $country['name']['common'] ?? null;
+            $code = $country['cca2'] ?? null;
+            $region = $country['region'] ?? null;
+
+            if (!$name || !$code) {
+                continue;
+            }
+
+            try {
+                $connection->insertOnDuplicate($tableName, [
+                    'name' => $name,
+                    'code' => strtoupper(substr($code, 0, 2)),
+                    'region' => $region
+                ], ['name', 'region', 'updated_at']);
+            } catch (\Throwable $e) {
+                $this->logger->error(sprintf('[CountrySync] Insert failed for %s (%s): %s', $name, $code, $e->getMessage()));
+            }
+        }
+    }
+}

--- a/Vendor_CountrySync/README.md
+++ b/Vendor_CountrySync/README.md
@@ -1,0 +1,25 @@
+# Vendor_CountrySync
+
+Ejemplo de integración REST en Magento 2: sincroniza países desde una API pública hacia una tabla custom.
+Incluye **cron** y **comando CLI**.
+
+## Instalación
+1. Copiar en `app/code/Vendor/CountrySync`.
+2. Ejecutar:
+   ```bash
+   bin/magento module:enable Vendor_CountrySync
+   bin/magento setup:upgrade
+   bin/magento cache:flush
+   ```
+
+## Uso
+- Ejecutar sincronización manual:
+  ```bash
+  bin/magento vendor:countries:sync
+  ```
+- Cron corre diariamente a las 03:00 (ver `etc/crontab.xml`).
+
+## Notas de buenas prácticas
+- Uso de **interfaces** y **preference** en `etc/di.xml`.
+- Manejo de errores y logs.
+- Persistencia con `insertOnDuplicate` y `db_schema.xml` declarativo.

--- a/Vendor_CountrySync/composer.json
+++ b/Vendor_CountrySync/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "vendor/module-countrysync",
+  "description": "Magento 2 integration example: sync countries from a public REST API into a custom table, with cron and CLI.",
+  "type": "magento2-module",
+  "require": {
+    "php": ">=8.1"
+  },
+  "autoload": {
+    "files": [
+      "registration.php"
+    ],
+    "psr-4": {
+      "Vendor\\CountrySync\\": ""
+    }
+  }
+}

--- a/Vendor_CountrySync/etc/crontab.xml
+++ b/Vendor_CountrySync/etc/crontab.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/crontab.xsd">
+    <group id="default">
+        <job name="vendor_country_sync" instance="Vendor\CountrySync\Model\CountryService" method="syncCountries">
+            <schedule>0 3 * * *</schedule>
+        </job>
+    </group>
+</config>

--- a/Vendor_CountrySync/etc/db_schema.xml
+++ b/Vendor_CountrySync/etc/db_schema.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="vendor_country" resource="default" engine="innodb" comment="Vendor Countries">
+        <column xsi:type="int" name="entity_id" nullable="false" identity="true" unsigned="true" comment="ID" />
+        <column xsi:type="text" name="name" nullable="false" length="255" comment="Country Name"/>
+        <column xsi:type="text" name="code" nullable="false" length="2" comment="ISO2 Code"/>
+        <column xsi:type="text" name="region" nullable="true" length="255" comment="Region"/>
+        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP" comment="Updated At"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="entity_id"/>
+        </constraint>
+        <constraint xsi:type="unique" referenceId="VENDOR_COUNTRY_CODE_UNQ">
+            <column name="code"/>
+        </constraint>
+        <index referenceId="VENDOR_COUNTRY_REGION_IDX">
+            <column name="region"/>
+        </index>
+    </table>
+</schema>

--- a/Vendor_CountrySync/etc/di.xml
+++ b/Vendor_CountrySync/etc/di.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Vendor\CountrySync\Api\CountryServiceInterface" type="Vendor\CountrySync\Model\CountryService"/>
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="vendor_countries_sync" xsi:type="object">Vendor\CountrySync\Console\Command\SyncCountriesCommand</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/Vendor_CountrySync/etc/module.xml
+++ b/Vendor_CountrySync/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Vendor_CountrySync" setup_version="1.0.0"/>
+</config>

--- a/Vendor_CountrySync/registration.php
+++ b/Vendor_CountrySync/registration.php
@@ -1,0 +1,3 @@
+<?php
+use Magento\Framework\Component\ComponentRegistrar;
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Vendor_CountrySync', __DIR__);


### PR DESCRIPTION
feat: add Magento 2 module Vendor_CountrySync for external API country data synchronization

This module integrates with the REST Countries API (https://restcountries.com/) to fetch and store country data in a custom Magento 2 table. Supports both scheduled and on-demand synchronization.

Features:
- Custom DB table (vendor_country) with indexes and unique constraints
- Service class to handle API requests and data persistence
- Cron job for daily synchronization at 03:00
- CLI command: bin/magento vendor:countries:sync for manual updates
- PSR-12 compliant code with clear separation of concerns
